### PR TITLE
Add folder sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ SAMBA_USERNAME="backupuser"
 SAMBA_PASSWORD="mypassword"
 ```
 
+Configuration option to run sync-only by default
+
+- `SYNC_ONLY_DEFAULT` in `config.conf` controls whether the script runs in sync-only mode when no CLI `--sync-only` flag is given.
+- Valid values: `"true"` or `"false"`.
+- The installer (`configure.sh`) prompts for this setting during configuration.
+- CLI `--sync-only` always overrides the config value for a single run.
+
+Example config snippet:
+
+```bash
+SYNC_ONLY_DEFAULT="false"   # set to "true" to make the script run sync-only by default
+```
+
 ---
 
 ## 🧪 Dry Run Mode
@@ -218,12 +231,13 @@ Run only a sync to remote (no zip):
 ./startBackup.sh --sync-only /path/to/local/folder
 ```
 
-This will:
-- Mount the configured Samba/CIFS network share
-- Rsync the contents of the specified local folder to the remote mount (preserving hierarchy)
-- Unmount the share and exit
+If you omit the path, the script will read `SOURCE_DIRS_LIST` from `config.conf` and sync each path listed there:
 
-Use `--dry-run` together with `--sync-only` to simulate the rsync operation.
+```bash
+./startBackup.sh --sync-only
+```
+
+Use `--dry-run` with `--sync-only` to simulate the sync operation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,19 @@ This will:
 - Print connection test results
 - Exit without performing any backup or file operations
 
+Run only a sync to remote (no zip):
+
+```bash
+./startBackup.sh --sync-only /path/to/local/folder
+```
+
+This will:
+- Mount the configured Samba/CIFS network share
+- Rsync the contents of the specified local folder to the remote mount (preserving hierarchy)
+- Unmount the share and exit
+
+Use `--dry-run` together with `--sync-only` to simulate the rsync operation.
+
 ---
 
 ## 📜 License

--- a/config.conf.example
+++ b/config.conf.example
@@ -59,6 +59,10 @@ MYSQL_PORT="3306"
 # Space-separated list of databases to exclude from backup.
 # Default: mysql phpmyadmin performance_schema
 MYSQL_EXCLUDE_DBS="mysql phpmyadmin"
+# === SYNC-ONLY DEFAULT ===
+# If set to "true", the script will run in sync-only mode by default (no zip),
+# using paths from SOURCE_DIRS_LIST. CLI --sync-only still overrides this.
+SYNC_ONLY_DEFAULT="false"
 
 # === SAMBA/CIFS SETTINGS ===
 ###########################

--- a/configure.sh
+++ b/configure.sh
@@ -12,19 +12,53 @@ declare -A config_values
 load_existing_config() {
     if [ -f "$CONFIG_FILE" ]; then
         while IFS= read -r line; do
-    # Use readline editable input with prefilled default when available
+            if [[ "$line" =~ ^([A-Za-z0-9_]+)="?(.*)"?$ ]]; then
+                key="${BASH_REMATCH[1]}"
+                value="${BASH_REMATCH[2]}"
+                config_values[$key]="$value"
+            fi
+        done < "$CONFIG_FILE"
+    fi
+}
+
+check_dependencies() {
+    echo "Checking required packages..."
+
+    missing=()
+    for pkg in rsync zip cifs-utils; do
+        if ! command -v "$pkg" >/dev/null 2>&1; then
+            missing+=("$pkg")
+        fi
+    done
+
+    if (( ${#missing[@]} > 0 )); then
+        echo "Installing missing packages: ${missing[*]}"
+        apt-get update
+        apt-get install -y "${missing[@]}"
+    else
+        echo "All required packages are installed."
+    fi
+}
+
+prompt_user_input() {
+    echo ""
+    echo "=== Configuration ==="
+
+    # PROGRAM_DIR
     default_program_dir="${config_values[PROGRAM_DIR]:-$(pwd)}"
     read -e -i "$default_program_dir" -p "Backup script directory: " val
     config_values[PROGRAM_DIR]="${val:-$default_program_dir}"
-                value="${BASH_REMATCH[2]}"
+
+    # SOURCE/EXCLUDE lists
     default_source_list="${config_values[SOURCE_DIRS_LIST]:-${config_values[PROGRAM_DIR]}/sourceList.txt}"
     read -e -i "$default_source_list" -p "Path to source list file: " val
     config_values[SOURCE_DIRS_LIST]="${val:-$default_source_list}"
-        done < "$CONFIG_FILE"
+
     default_exclude_list="${config_values[EXCLUDE_LIST]:-${config_values[PROGRAM_DIR]}/excludeList.txt}"
     read -e -i "$default_exclude_list" -p "Path to exclude list file: " val
     config_values[EXCLUDE_LIST]="${val:-$default_exclude_list}"
 
+    # Samba settings
     default_samba_server="${config_values[SAMBA_SERVER]:-}"
     read -e -i "$default_samba_server" -p "Samba server IP or hostname: " val
     config_values[SAMBA_SERVER]="${val:-$default_samba_server}"
@@ -41,12 +75,11 @@ load_existing_config() {
     read -e -i "$default_samba_user" -p "Samba username: " val
     config_values[SAMBA_USERNAME]="${val:-$default_samba_user}"
 
-    # Passwords are read silently; pressing Enter keeps existing value
     read -rsp "Samba password (press enter to keep existing): " val
     echo ""
     config_values[SAMBA_PASSWORD]="${val:-${config_values[SAMBA_PASSWORD]:-}}"
-        echo "All required packages are installed."
-    fi
+
+    # MySQL settings
     default_mysql_enabled="${config_values[MYSQL_BACKUP_ENABLED]:-false}"
     read -e -i "$default_mysql_enabled" -p "Enable MySQL database backup? (true/false): " val
     config_values[MYSQL_BACKUP_ENABLED]="${val:-$default_mysql_enabled}"
@@ -73,37 +106,10 @@ load_existing_config() {
         config_values[MYSQL_EXCLUDE_DBS]="${val:-$default_mysql_exclude}"
     fi
 
+    # Sync-only default
     default_sync_only="${config_values[SYNC_ONLY_DEFAULT]:-false}"
     read -e -i "$default_sync_only" -p "Set sync-only by default? (true/false): " val
     config_values[SYNC_ONLY_DEFAULT]="${val:-$default_sync_only}"
-
-    read -rp "Samba username (default: ${config_values[SAMBA_USERNAME]:-}): " val
-    config_values[SAMBA_USERNAME]="${val:-${config_values[SAMBA_USERNAME]:-}}"
-
-    read -rsp "Samba password (press enter to keep existing): " val
-    echo ""
-    config_values[SAMBA_PASSWORD]="${val:-${config_values[SAMBA_PASSWORD]:-}}"
-
-    # === MySQL Backup Settings ===
-    read -rp "Enable MySQL database backup? (true/false) [${config_values[MYSQL_BACKUP_ENABLED]:-false}]: " val
-    config_values[MYSQL_BACKUP_ENABLED]="${val:-${config_values[MYSQL_BACKUP_ENABLED]:-false}}"
-
-    if [[ "${config_values[MYSQL_BACKUP_ENABLED]}" == "true" ]]; then
-        read -rp "MySQL username for backup (default: ${config_values[MYSQL_USERNAME]:-}): " val
-        config_values[MYSQL_USERNAME]="${val:-${config_values[MYSQL_USERNAME]:-}}"
-        read -rsp "MySQL password for backup (press enter to keep existing): " val
-        echo ""
-        config_values[MYSQL_PASSWORD]="${val:-${config_values[MYSQL_PASSWORD]:-}}"
-        read -rp "MySQL host (default: ${config_values[MYSQL_HOST]:-localhost}): " val
-        config_values[MYSQL_HOST]="${val:-${config_values[MYSQL_HOST]:-localhost}}"
-        read -rp "MySQL port (default: ${config_values[MYSQL_PORT]:-3306}): " val
-        config_values[MYSQL_PORT]="${val:-${config_values[MYSQL_PORT]:-3306}}"
-        read -rp "Excluded databases (space-separated, default: ${config_values[MYSQL_EXCLUDE_DBS]:-mysql phpmyadmin}): " val
-        config_values[MYSQL_EXCLUDE_DBS]="${val:-${config_values[MYSQL_EXCLUDE_DBS]:-mysql phpmyadmin}}"
-    fi
-
-    read -rp "Set sync-only by default? (true/false) [${config_values[SYNC_ONLY_DEFAULT]:-false}]: " val
-    config_values[SYNC_ONLY_DEFAULT]="${val:-${config_values[SYNC_ONLY_DEFAULT]:-false}}"
 }
 
 write_config() {
@@ -230,13 +236,13 @@ setup_cron_job() {
         *) echo "Invalid option. Skipping."; return ;;
     esac
 
-    script_path="$SCRIPT_DIR/startBackup.sh"
-    log_path="/var/log/autoBackup.log"
-    cron_cmd="$cron_expr $script_path >>$log_path 2>&1"
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
     script_path="$SCRIPT_DIR/startBackup.sh"
     log_path="/var/log/autoBackup.log"
     cron_cmd="$cron_expr $script_path >>$log_path 2>&1"
+
+    current_cron=$(crontab -l 2>/dev/null || true)
+
     if echo "$current_cron" | grep -qF "$script_path"; then
         echo "ℹ Cron job already exists for this script. Skipping."
     else

--- a/configure.sh
+++ b/configure.sh
@@ -9,6 +9,18 @@ CONFIG_EXAMPLE="./config.conf.example"
 
 declare -A config_values
 
+load_existing_config() {
+    if [ -f "$CONFIG_FILE" ]; then
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^([A-Za-z0-9_]+)="(.*)" ]]; then
+                key="${BASH_REMATCH[1]}"
+                value="${BASH_REMATCH[2]}"
+                config_values[$key]="$value"
+            fi
+        done < "$CONFIG_FILE"
+    fi
+}
+
 check_dependencies() {
     echo "Checking required packages..."
 
@@ -31,31 +43,51 @@ check_dependencies() {
 prompt_user_input() {
     echo ""
     echo "=== Configuration ==="
+    read -rp "Backup script directory (default: ${config_values[PROGRAM_DIR]:-$(pwd)}): " val
+    config_values[PROGRAM_DIR]="${val:-${config_values[PROGRAM_DIR]:-$(pwd)}}"
 
-    read -rp "Backup script directory (default: $(pwd)): " val
-    config_values[PROGRAM_DIR]="${val:-$(pwd)}"
+    read -rp "Path to source list file (default: ${config_values[SOURCE_DIRS_LIST]:-${config_values[PROGRAM_DIR]}/sourceList.txt}): " val
+    config_values[SOURCE_DIRS_LIST]="${val:-${config_values[SOURCE_DIRS_LIST]:-${config_values[PROGRAM_DIR]}/sourceList.txt}}"
 
-    read -rp "Path to source list file (default: \$PROGRAM_DIR/sourceList.txt): " val
-    config_values[SOURCE_DIRS_LIST]="${val:-${config_values[PROGRAM_DIR]}/sourceList.txt}"
+    read -rp "Path to exclude list file (default: ${config_values[EXCLUDE_LIST]:-${config_values[PROGRAM_DIR]}/excludeList.txt}): " val
+    config_values[EXCLUDE_LIST]="${val:-${config_values[EXCLUDE_LIST]:-${config_values[PROGRAM_DIR]}/excludeList.txt}}"
 
-    read -rp "Path to exclude list file (default: \$PROGRAM_DIR/excludeList.txt): " val
-    config_values[EXCLUDE_LIST]="${val:-${config_values[PROGRAM_DIR]}/excludeList.txt}"
+    read -rp "Samba server IP or hostname (default: ${config_values[SAMBA_SERVER]:-}): " val
+    config_values[SAMBA_SERVER]="${val:-${config_values[SAMBA_SERVER]:-}}"
 
-    read -rp "Samba server IP or hostname: " val
-    config_values[SAMBA_SERVER]="$val"
+    read -rp "Samba folder (e.g., /backupTarget) (default: ${config_values[SAMBA_FOLDER]:-}): " val
+    config_values[SAMBA_FOLDER]="${val:-${config_values[SAMBA_FOLDER]:-}}"
 
-    read -rp "Samba folder (e.g., /backupTarget): " val
-    config_values[SAMBA_FOLDER]="$val"
+    read -rp "Samba version (e.g., 1.0, 3.0) (default: ${config_values[SAMBA_VERSION]:-1.0}): " val
+    config_values[SAMBA_VERSION]="${val:-${config_values[SAMBA_VERSION]:-1.0}}"
 
-    read -rp "Samba version (e.g., 1.0, 3.0): " val
-    config_values[SAMBA_VERSION]="$val"
+    read -rp "Samba username (default: ${config_values[SAMBA_USERNAME]:-}): " val
+    config_values[SAMBA_USERNAME]="${val:-${config_values[SAMBA_USERNAME]:-}}"
 
-    read -rp "Samba username: " val
-    config_values[SAMBA_USERNAME]="$val"
-
-    read -rsp "Samba password: " val
+    read -rsp "Samba password (press enter to keep existing): " val
     echo ""
-    config_values[SAMBA_PASSWORD]="$val"
+    config_values[SAMBA_PASSWORD]="${val:-${config_values[SAMBA_PASSWORD]:-}}"
+
+    # === MySQL Backup Settings ===
+    read -rp "Enable MySQL database backup? (true/false) [${config_values[MYSQL_BACKUP_ENABLED]:-false}]: " val
+    config_values[MYSQL_BACKUP_ENABLED]="${val:-${config_values[MYSQL_BACKUP_ENABLED]:-false}}"
+
+    if [[ "${config_values[MYSQL_BACKUP_ENABLED]}" == "true" ]]; then
+        read -rp "MySQL username for backup (default: ${config_values[MYSQL_USERNAME]:-}): " val
+        config_values[MYSQL_USERNAME]="${val:-${config_values[MYSQL_USERNAME]:-}}"
+        read -rsp "MySQL password for backup (press enter to keep existing): " val
+        echo ""
+        config_values[MYSQL_PASSWORD]="${val:-${config_values[MYSQL_PASSWORD]:-}}"
+        read -rp "MySQL host (default: ${config_values[MYSQL_HOST]:-localhost}): " val
+        config_values[MYSQL_HOST]="${val:-${config_values[MYSQL_HOST]:-localhost}}"
+        read -rp "MySQL port (default: ${config_values[MYSQL_PORT]:-3306}): " val
+        config_values[MYSQL_PORT]="${val:-${config_values[MYSQL_PORT]:-3306}}"
+        read -rp "Excluded databases (space-separated, default: ${config_values[MYSQL_EXCLUDE_DBS]:-mysql phpmyadmin}): " val
+        config_values[MYSQL_EXCLUDE_DBS]="${val:-${config_values[MYSQL_EXCLUDE_DBS]:-mysql phpmyadmin}}"
+    fi
+
+    read -rp "Set sync-only by default? (true/false) [${config_values[SYNC_ONLY_DEFAULT]:-false}]: " val
+    config_values[SYNC_ONLY_DEFAULT]="${val:-${config_values[SYNC_ONLY_DEFAULT]:-false}}"
     
     read -rp "Do you want to sync the folders only instead of compressing and uploading the archive? (true/false) [false]: " val
     config_values[SYNC_ONLY_DEFAULT]="${val:-false}"
@@ -205,32 +237,10 @@ setup_cron_job() {
 
 echo "Welcome to Auto Backup installer"
 
-if [ -f "$CONFIG_FILE" ]; then
-    echo "Config file already exists at $CONFIG_FILE."
-    if confirm; then
-            # === MySQL Backup Settings ===
-            read -rp "Enable MySQL database backup? (true/false) [true]: " val
-            config_values[MYSQL_BACKUP_ENABLED]="${val:-true}"
+read -rp "Path to config file to use (default: ./config.conf): " input_cfg
+CONFIG_FILE="${input_cfg:-./config.conf}"
 
-            if [[ "${config_values[MYSQL_BACKUP_ENABLED]}" == "true" ]]; then
-                read -rp "MySQL username for backup: " val
-                config_values[MYSQL_USERNAME]="$val"
-                read -rsp "MySQL password for backup: " val
-                echo ""
-                config_values[MYSQL_PASSWORD]="$val"
-                read -rp "MySQL host (default: localhost): " val
-                config_values[MYSQL_HOST]="${val:-localhost}"
-                read -rp "MySQL port (default: 3306): " val
-                config_values[MYSQL_PORT]="${val:-3306}"
-                read -rp "Excluded databases (space-separated, default: mysql phpmyadmin): " val
-                config_values[MYSQL_EXCLUDE_DBS]="${val:-mysql phpmyadmin}"
-            fi
-        echo "Reconfiguring..."
-    else
-        echo "Installation cancelled."
-        exit 0
-    fi
-fi
+load_existing_config
 
 check_dependencies
 prompt_user_input

--- a/configure.sh
+++ b/configure.sh
@@ -56,6 +56,9 @@ prompt_user_input() {
     read -rsp "Samba password: " val
     echo ""
     config_values[SAMBA_PASSWORD]="$val"
+    
+    read -rp "Do you want to sync the folders only instead of compressing and uploading the archive? (true/false) [false]: " val
+    config_values[SYNC_ONLY_DEFAULT]="${val:-false}"
 }
 
 write_config() {
@@ -239,3 +242,11 @@ setup_cron_job
 echo ""
 echo "✅ Installation complete. You can now run: ./startBackup.sh"
 echo "To configure the script, edit $CONFIG_FILE or run the installer again."
+echo ""
+echo "Notes:"
+echo " - You can sync folders directly to the remote (no zip) with the --sync-only option."
+echo "   If you call: ./startBackup.sh --sync-only (without a path), the script will read the paths from SOURCE_DIRS_LIST in your config and sync each listed path."
+echo ""
+echo "Examples:" 
+echo "  ./startBackup.sh --sync-only /var/www        # sync a single folder"
+echo "  ./startBackup.sh --sync-only                # sync all paths listed in SOURCE_DIRS_LIST"

--- a/configure.sh
+++ b/configure.sh
@@ -12,54 +12,70 @@ declare -A config_values
 load_existing_config() {
     if [ -f "$CONFIG_FILE" ]; then
         while IFS= read -r line; do
-            if [[ "$line" =~ ^([A-Za-z0-9_]+)="(.*)" ]]; then
-                key="${BASH_REMATCH[1]}"
+    # Use readline editable input with prefilled default when available
+    default_program_dir="${config_values[PROGRAM_DIR]:-$(pwd)}"
+    read -e -i "$default_program_dir" -p "Backup script directory: " val
+    config_values[PROGRAM_DIR]="${val:-$default_program_dir}"
                 value="${BASH_REMATCH[2]}"
-                config_values[$key]="$value"
-            fi
+    default_source_list="${config_values[SOURCE_DIRS_LIST]:-${config_values[PROGRAM_DIR]}/sourceList.txt}"
+    read -e -i "$default_source_list" -p "Path to source list file: " val
+    config_values[SOURCE_DIRS_LIST]="${val:-$default_source_list}"
         done < "$CONFIG_FILE"
-    fi
-}
+    default_exclude_list="${config_values[EXCLUDE_LIST]:-${config_values[PROGRAM_DIR]}/excludeList.txt}"
+    read -e -i "$default_exclude_list" -p "Path to exclude list file: " val
+    config_values[EXCLUDE_LIST]="${val:-$default_exclude_list}"
 
-check_dependencies() {
-    echo "Checking required packages..."
+    default_samba_server="${config_values[SAMBA_SERVER]:-}"
+    read -e -i "$default_samba_server" -p "Samba server IP or hostname: " val
+    config_values[SAMBA_SERVER]="${val:-$default_samba_server}"
 
-    missing=()
-    for pkg in rsync zip cifs-utils; do
-        if ! command -v "$pkg" >/dev/null 2>&1; then
-            missing+=("$pkg")
-        fi
-    done
+    default_samba_folder="${config_values[SAMBA_FOLDER]:-}"
+    read -e -i "$default_samba_folder" -p "Samba folder (e.g., /backupTarget): " val
+    config_values[SAMBA_FOLDER]="${val:-$default_samba_folder}"
 
-    if (( ${#missing[@]} > 0 )); then
-        echo "Installing missing packages: ${missing[*]}"
-        apt-get update
-        apt-get install -y "${missing[@]}"
-    else
+    default_samba_version="${config_values[SAMBA_VERSION]:-1.0}"
+    read -e -i "$default_samba_version" -p "Samba version (e.g., 1.0, 3.0): " val
+    config_values[SAMBA_VERSION]="${val:-$default_samba_version}"
+
+    default_samba_user="${config_values[SAMBA_USERNAME]:-}"
+    read -e -i "$default_samba_user" -p "Samba username: " val
+    config_values[SAMBA_USERNAME]="${val:-$default_samba_user}"
+
+    # Passwords are read silently; pressing Enter keeps existing value
+    read -rsp "Samba password (press enter to keep existing): " val
+    echo ""
+    config_values[SAMBA_PASSWORD]="${val:-${config_values[SAMBA_PASSWORD]:-}}"
         echo "All required packages are installed."
     fi
-}
+    default_mysql_enabled="${config_values[MYSQL_BACKUP_ENABLED]:-false}"
+    read -e -i "$default_mysql_enabled" -p "Enable MySQL database backup? (true/false): " val
+    config_values[MYSQL_BACKUP_ENABLED]="${val:-$default_mysql_enabled}"
 
-prompt_user_input() {
-    echo ""
-    echo "=== Configuration ==="
-    read -rp "Backup script directory (default: ${config_values[PROGRAM_DIR]:-$(pwd)}): " val
-    config_values[PROGRAM_DIR]="${val:-${config_values[PROGRAM_DIR]:-$(pwd)}}"
+    if [[ "${config_values[MYSQL_BACKUP_ENABLED]}" == "true" ]]; then
+        default_mysql_user="${config_values[MYSQL_USERNAME]:-}"
+        read -e -i "$default_mysql_user" -p "MySQL username for backup: " val
+        config_values[MYSQL_USERNAME]="${val:-$default_mysql_user}"
 
-    read -rp "Path to source list file (default: ${config_values[SOURCE_DIRS_LIST]:-${config_values[PROGRAM_DIR]}/sourceList.txt}): " val
-    config_values[SOURCE_DIRS_LIST]="${val:-${config_values[SOURCE_DIRS_LIST]:-${config_values[PROGRAM_DIR]}/sourceList.txt}}"
+        read -rsp "MySQL password for backup (press enter to keep existing): " val
+        echo ""
+        config_values[MYSQL_PASSWORD]="${val:-${config_values[MYSQL_PASSWORD]:-}}"
 
-    read -rp "Path to exclude list file (default: ${config_values[EXCLUDE_LIST]:-${config_values[PROGRAM_DIR]}/excludeList.txt}): " val
-    config_values[EXCLUDE_LIST]="${val:-${config_values[EXCLUDE_LIST]:-${config_values[PROGRAM_DIR]}/excludeList.txt}}"
+        default_mysql_host="${config_values[MYSQL_HOST]:-localhost}"
+        read -e -i "$default_mysql_host" -p "MySQL host: " val
+        config_values[MYSQL_HOST]="${val:-$default_mysql_host}"
 
-    read -rp "Samba server IP or hostname (default: ${config_values[SAMBA_SERVER]:-}): " val
-    config_values[SAMBA_SERVER]="${val:-${config_values[SAMBA_SERVER]:-}}"
+        default_mysql_port="${config_values[MYSQL_PORT]:-3306}"
+        read -e -i "$default_mysql_port" -p "MySQL port: " val
+        config_values[MYSQL_PORT]="${val:-$default_mysql_port}"
 
-    read -rp "Samba folder (e.g., /backupTarget) (default: ${config_values[SAMBA_FOLDER]:-}): " val
-    config_values[SAMBA_FOLDER]="${val:-${config_values[SAMBA_FOLDER]:-}}"
+        default_mysql_exclude="${config_values[MYSQL_EXCLUDE_DBS]:-mysql phpmyadmin}"
+        read -e -i "$default_mysql_exclude" -p "Excluded databases (space-separated): " val
+        config_values[MYSQL_EXCLUDE_DBS]="${val:-$default_mysql_exclude}"
+    fi
 
-    read -rp "Samba version (e.g., 1.0, 3.0) (default: ${config_values[SAMBA_VERSION]:-1.0}): " val
-    config_values[SAMBA_VERSION]="${val:-${config_values[SAMBA_VERSION]:-1.0}}"
+    default_sync_only="${config_values[SYNC_ONLY_DEFAULT]:-false}"
+    read -e -i "$default_sync_only" -p "Set sync-only by default? (true/false): " val
+    config_values[SYNC_ONLY_DEFAULT]="${val:-$default_sync_only}"
 
     read -rp "Samba username (default: ${config_values[SAMBA_USERNAME]:-}): " val
     config_values[SAMBA_USERNAME]="${val:-${config_values[SAMBA_USERNAME]:-}}"

--- a/configure.sh
+++ b/configure.sh
@@ -88,9 +88,6 @@ prompt_user_input() {
 
     read -rp "Set sync-only by default? (true/false) [${config_values[SYNC_ONLY_DEFAULT]:-false}]: " val
     config_values[SYNC_ONLY_DEFAULT]="${val:-${config_values[SYNC_ONLY_DEFAULT]:-false}}"
-    
-    read -rp "Do you want to sync the folders only instead of compressing and uploading the archive? (true/false) [false]: " val
-    config_values[SYNC_ONLY_DEFAULT]="${val:-false}"
 }
 
 write_config() {
@@ -220,9 +217,10 @@ setup_cron_job() {
     script_path="$SCRIPT_DIR/startBackup.sh"
     log_path="/var/log/autoBackup.log"
     cron_cmd="$cron_expr $script_path >>$log_path 2>&1"
-
-    current_cron=$(crontab -l 2>/dev/null)
-
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    script_path="$SCRIPT_DIR/startBackup.sh"
+    log_path="/var/log/autoBackup.log"
+    cron_cmd="$cron_expr $script_path >>$log_path 2>&1"
     if echo "$current_cron" | grep -qF "$script_path"; then
         echo "ℹ Cron job already exists for this script. Skipping."
     else

--- a/startBackup.sh
+++ b/startBackup.sh
@@ -16,6 +16,8 @@
     CLI_PASSWORD=""
     DRY_RUN=false
     TEST_SAMBA=false
+    SYNC_ONLY=false
+    SYNC_PATH=""
 
     print_help() {
         echo "Usage: $0 [--config <path>] [--user <username>] [--pass <password>] [--dry-run] [--help]"
@@ -26,6 +28,7 @@
         echo "      --pass <password>   Samba password (overrides config)"
         echo "      --dry-run           Run full flow in simulation mode (no actual copy)"
         echo "      --test-samba        Only test Samba/CIFS connection (mount & unmount)"
+        echo "      --sync-only <path>   Sync the specified local folder to the remote share (no zip)."
         echo "  -h, --help              Show this help message"
         exit 0
     }
@@ -52,6 +55,11 @@
                 --test-samba)
                     TEST_SAMBA=true
                     shift
+                    ;;
+                --sync-only)
+                    SYNC_ONLY=true
+                    SYNC_PATH="$2"
+                    shift 2
                     ;;
                 -h|--help)
                     print_help
@@ -151,6 +159,32 @@
     change_to_program_dir() {
         cd "$PROGRAM_DIR" || { echo "Cannot change directory to $PROGRAM_DIR"; exit 1; }
     }
+
+sync_specified_folder() {
+    if [[ -z "$SYNC_PATH" ]]; then
+        echo "Error: --sync-only requires a local path argument."
+        exit 1
+    fi
+
+    if [ ! -d "$SYNC_PATH" ]; then
+        echo "Error: specified sync path does not exist: $SYNC_PATH"
+        exit 1
+    fi
+
+    echo "Syncing $SYNC_PATH to remote share ${SAMBA_SERVER}:${SAMBA_FOLDER}..."
+    mount_remote_storage
+
+    # Use rsync to copy the folder contents to the mounted remote; preserve hierarchy
+    if $DRY_RUN; then
+        echo "DRY RUN: rsync -avhn --delete \"$SYNC_PATH/\" \"$LOCAL_MOUNT_POINT/\""
+        rsync -avhn --delete "$SYNC_PATH/" "$LOCAL_MOUNT_POINT/"
+    else
+        rsync -avh --delete "$SYNC_PATH/" "$LOCAL_MOUNT_POINT/"
+    fi
+
+    unmount_remote_storage
+    echo "Sync completed."
+}
 
     copy_source_dirs() {
         echo "Copying source directories..."

--- a/startBackup.sh
+++ b/startBackup.sh
@@ -28,7 +28,8 @@
         echo "      --pass <password>   Samba password (overrides config)"
         echo "      --dry-run           Run full flow in simulation mode (no actual copy)"
         echo "      --test-samba        Only test Samba/CIFS connection (mount & unmount)"
-        echo "      --sync-only <path>   Sync the specified local folder to the remote share (no zip)."
+    echo "      --sync-only <path>   Sync the specified local folder to the remote share (no zip)."
+    echo "                           If no <path> is provided, the script will read paths from SOURCE_DIRS_LIST in the config and sync each listed path."
         echo "  -h, --help              Show this help message"
         exit 0
     }
@@ -58,8 +59,13 @@
                     ;;
                 --sync-only)
                     SYNC_ONLY=true
-                    SYNC_PATH="$2"
-                    shift 2
+                    # optional path argument: only consume next token if it's not another flag
+                    if [[ -n "$2" && "$2" != -* ]]; then
+                        SYNC_PATH="$2"
+                        shift 2
+                    else
+                        shift
+                    fi
                     ;;
                 -h|--help)
                     print_help
@@ -93,6 +99,9 @@
         MYSQL_HOST="${MYSQL_HOST:-localhost}"
         MYSQL_PORT="${MYSQL_PORT:-3306}"
         MYSQL_EXCLUDE_DBS="${MYSQL_EXCLUDE_DBS:-mysql phpmyadmin}"
+
+        # Sync-only default from config
+        SYNC_ONLY_DEFAULT="${SYNC_ONLY_DEFAULT:-false}"
     }
     check_mysql_privileges() {
         echo "Checking MySQL user privileges for export..."
@@ -160,31 +169,66 @@
         cd "$PROGRAM_DIR" || { echo "Cannot change directory to $PROGRAM_DIR"; exit 1; }
     }
 
-sync_specified_folder() {
-    if [[ -z "$SYNC_PATH" ]]; then
-        echo "Error: --sync-only requires a local path argument."
-        exit 1
-    fi
+    sync_specified_folder() {
+        # If no explicit path provided, use SOURCE_DIRS_LIST
+        local paths=()
+        if [[ -n "$SYNC_PATH" ]]; then
+            paths=("$SYNC_PATH")
+        else
+            if [ ! -f "$SOURCE_DIRS_LIST" ]; then
+                echo "Error: source list not found: $SOURCE_DIRS_LIST"
+                exit 1
+            fi
+            while IFS= read -r line || [ -n "$line" ]; do
+                # skip empty lines and comments
+                line_trimmed="$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+                [[ -z "$line_trimmed" || "$line_trimmed" =~ ^# ]] && continue
+                paths+=("$line_trimmed")
+            done < "$SOURCE_DIRS_LIST"
+        fi
 
-    if [ ! -d "$SYNC_PATH" ]; then
-        echo "Error: specified sync path does not exist: $SYNC_PATH"
-        exit 1
-    fi
+        if [ ${#paths[@]} -eq 0 ]; then
+            echo "No paths to sync."
+            return
+        fi
 
-    echo "Syncing $SYNC_PATH to remote share ${SAMBA_SERVER}:${SAMBA_FOLDER}..."
-    mount_remote_storage
+        mount_remote_storage
 
-    # Use rsync to copy the folder contents to the mounted remote; preserve hierarchy
-    if $DRY_RUN; then
-        echo "DRY RUN: rsync -avhn --delete \"$SYNC_PATH/\" \"$LOCAL_MOUNT_POINT/\""
-        rsync -avhn --delete "$SYNC_PATH/" "$LOCAL_MOUNT_POINT/"
-    else
-        rsync -avh --delete "$SYNC_PATH/" "$LOCAL_MOUNT_POINT/"
-    fi
+        for p in "${paths[@]}"; do
+            # expand globs
+            for expanded in $(eval echo $p); do
+                if [ ! -e "$expanded" ]; then
+                    echo "Skipping missing path: $expanded"
+                    continue
+                fi
 
-    unmount_remote_storage
-    echo "Sync completed."
-}
+                # calculate a relative path base so we don't include leading /
+                relpath="${expanded#/}"
+                if [ -d "$expanded" ]; then
+                    dest="$LOCAL_MOUNT_POINT/$relpath"
+                    echo "Syncing directory $expanded -> $dest/"
+                    mkdir -p "$dest"
+                    if $DRY_RUN; then
+                        rsync -avhn --delete "$expanded/" "$dest/"
+                    else
+                        rsync -avh --delete "$expanded/" "$dest/"
+                    fi
+                else
+                    dest_dir="$(dirname "$LOCAL_MOUNT_POINT/$relpath")"
+                    echo "Syncing file $expanded -> $dest_dir/"
+                    mkdir -p "$dest_dir"
+                    if $DRY_RUN; then
+                        rsync -avhn --delete "$expanded" "$dest_dir/"
+                    else
+                        rsync -avh --delete "$expanded" "$dest_dir/"
+                    fi
+                fi
+            done
+        done
+
+        unmount_remote_storage
+        echo "Sync completed."
+    }
 
     copy_source_dirs() {
         echo "Copying source directories..."
@@ -274,6 +318,18 @@ sync_specified_folder() {
     parse_arguments "$@"
     load_config
     resolve_credentials
+
+    # If config sets sync-only by default and CLI didn't enable/disable, enable it
+    if [[ "$SYNC_ONLY" != "true" && "$SYNC_ONLY_DEFAULT" == "true" ]]; then
+        SYNC_ONLY=true
+    fi
+
+    if $SYNC_ONLY; then
+        # run sync-only flow and exit
+        echo "Running in sync-only mode..."
+        sync_specified_folder
+        exit 0
+    fi
 
     if $TEST_SAMBA; then
         echo "Testing Samba/CIFS connection..."

--- a/startBackup.sh
+++ b/startBackup.sh
@@ -93,13 +93,6 @@
         MYSQL_PORT="${MYSQL_PORT:-3306}"
         MYSQL_EXCLUDE_DBS="${MYSQL_EXCLUDE_DBS:-mysql phpmyadmin}"
 
-        # Set MySQL defaults if not present
-        MYSQL_USERNAME="${MYSQL_USERNAME:-}" # must be set in config
-        MYSQL_PASSWORD="${MYSQL_PASSWORD:-}" # must be set in config
-        MYSQL_HOST="${MYSQL_HOST:-localhost}"
-        MYSQL_PORT="${MYSQL_PORT:-3306}"
-        MYSQL_EXCLUDE_DBS="${MYSQL_EXCLUDE_DBS:-mysql phpmyadmin}"
-
         # Sync-only default from config
         SYNC_ONLY_DEFAULT="${SYNC_ONLY_DEFAULT:-false}"
     }

--- a/startBackup.sh
+++ b/startBackup.sh
@@ -189,7 +189,7 @@
 
         for p in "${paths[@]}"; do
             # expand globs
-            for expanded in $(eval echo $p); do
+            for expanded in $(printf "%s\n" $p); do
                 if [ ! -e "$expanded" ]; then
                     echo "Skipping missing path: $expanded"
                     continue
@@ -202,18 +202,18 @@
                     echo "Syncing directory $expanded -> $dest/"
                     mkdir -p "$dest"
                     if $DRY_RUN; then
-                        rsync -avhn --delete "$expanded/" "$dest/"
+                        rsync -avhn --delete --exclude-from="$EXCLUDE_LIST" "$expanded/" "$dest/"
                     else
-                        rsync -avh --delete "$expanded/" "$dest/"
+                        rsync -avh --delete --exclude-from="$EXCLUDE_LIST" "$expanded/" "$dest/"
                     fi
                 else
                     dest_dir="$(dirname "$LOCAL_MOUNT_POINT/$relpath")"
                     echo "Syncing file $expanded -> $dest_dir/"
                     mkdir -p "$dest_dir"
                     if $DRY_RUN; then
-                        rsync -avhn --delete "$expanded" "$dest_dir/"
+                        rsync -avhn --delete --exclude-from="$EXCLUDE_LIST" "$expanded" "$dest_dir/"
                     else
-                        rsync -avh --delete "$expanded" "$dest_dir/"
+                        rsync -avh --delete --exclude-from="$EXCLUDE_LIST" "$expanded" "$dest_dir/"
                     fi
                 fi
             done


### PR DESCRIPTION
This pull request introduces a new "sync-only" mode to the backup script, allowing users to sync files directly to the remote share without creating a zip archive. The sync-only behavior can be set as the default in the configuration, and the installer has been enhanced to support this and other configuration improvements. The documentation and user experience have also been updated to reflect these changes.

**Sync-only mode and configuration:**

* Added support for a `--sync-only` CLI flag in `startBackup.sh`, enabling users to sync a specified folder (or all folders in `SOURCE_DIRS_LIST` if no path is given) directly to the remote share without zipping. [[1]](diffhunk://#diff-7ec1ae6f5776cbf2fe6ae6bcb5b6f79697df78996e652f73353041ae5311d0ceR19-R20) [[2]](diffhunk://#diff-7ec1ae6f5776cbf2fe6ae6bcb5b6f79697df78996e652f73353041ae5311d0ceR31-R32) [[3]](diffhunk://#diff-7ec1ae6f5776cbf2fe6ae6bcb5b6f79697df78996e652f73353041ae5311d0ceR60-R69) [[4]](diffhunk://#diff-7ec1ae6f5776cbf2fe6ae6bcb5b6f79697df78996e652f73353041ae5311d0ceR165-R225)
* Introduced `SYNC_ONLY_DEFAULT` in `config.conf` to control whether the script runs in sync-only mode by default. This can be set during installation via `configure.sh`, and is documented in `README.md` and `config.conf.example`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92-R104) [[2]](diffhunk://#diff-fd1519f6e656bc790f196c745c5d24a0dcfb205298e18305bf06a819a160cc43R62-R65) [[3]](diffhunk://#diff-0ba17b1855b0f97042c31b2b2c2fd2b075fa355a840b152f1959daf2a755266eL35-R112)
* The script now checks both CLI and config values to determine whether to run in sync-only mode, with CLI taking precedence.

**Installer and configuration improvements:**

* The installer (`configure.sh`) now loads existing config values and pre-fills prompts with current settings, including for MySQL and Samba options. It also prompts for the new sync-only default. [[1]](diffhunk://#diff-0ba17b1855b0f97042c31b2b2c2fd2b075fa355a840b152f1959daf2a755266eR12-R23) [[2]](diffhunk://#diff-0ba17b1855b0f97042c31b2b2c2fd2b075fa355a840b152f1959daf2a755266eL35-R112) [[3]](diffhunk://#diff-0ba17b1855b0f97042c31b2b2c2fd2b075fa355a840b152f1959daf2a755266eL205-R263)
* Improved cron job setup in `configure.sh` for robustness, and added clear post-install notes and examples for sync-only usage. [[1]](diffhunk://#diff-0ba17b1855b0f97042c31b2b2c2fd2b075fa355a840b152f1959daf2a755266eR239-R244) [[2]](diffhunk://#diff-0ba17b1855b0f97042c31b2b2c2fd2b075fa355a840b152f1959daf2a755266eR275-R282)

**Documentation updates:**

* Updated `README.md` to document the sync-only mode, configuration options, usage examples, and how the new behavior works with or without CLI flags. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92-R104) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R228-R241)

These changes make the backup script more flexible and user-friendly, especially for users who want to sync files without archiving them.